### PR TITLE
Switch deprecated tifffile.imsave to imwrite

### DIFF
--- a/databroker/assets/tests/test_handlers.py
+++ b/databroker/assets/tests/test_handlers.py
@@ -325,7 +325,7 @@ class Test_ADTiff_files(_with_path):
         self.fn_list = []
         for j in range(self.n_frames * self.fpp):
             fn = self.template % (self.filepath, self.fname, j)
-            tifffile.imsave(fn, np.ones(self.fr_shape) * j)
+            tifffile.imwrite(fn, np.ones(self.fr_shape) * j)
             self.fn_list.append(fn)
 
     def test_read(self):


### PR DESCRIPTION
`imsave` was renamed to `imwrite` in 2018, deprecated in 2022, and finally removed in 2025.

https://github.com/cgohlke/tifffile/blob/f1d053c1f9922a207b84df615eefa52c6fbae3bb/CHANGES.rst#revisions
